### PR TITLE
[PLT-988] Changes the release system

### DIFF
--- a/.github/workflows/release_tag.yaml
+++ b/.github/workflows/release_tag.yaml
@@ -21,12 +21,15 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          LATEST_TAG=$(git tag --sort=-creatordate --merged main | grep -E '^[0-9]+-' | head -n 1)
-          CURRENT_NUMBER=${LATEST_TAG%%-*}
-          if [ "$CURRENT_NUMBER" = "$LATEST_TAG" ]; then
-            CURRENT_NUMBER=0
+          LATEST_TAG="$(git tag --list "v*" | sort --version-sort | tail --lines 1)"
+
+          if [ -z "$LATEST_TAG" ]; then
+            MAJOR_VERSION=0
+            MINOR_VERSION=0
+          else
+            MAJOR_VERSION="$(echo "$LATEST_TAG" | cut -d '.' -f 1 | cut -d 'v' -f 2)"
+            MINOR_VERSION="$(echo "$LATEST_TAG" | cut -d '.' -f 2)"
           fi
-          NEW_NUMBER=$((CURRENT_NUMBER + 1))
-          NEW_TAG="${NEW_NUMBER}-$(git rev-parse --short=7 HEAD)"
-          git tag "$NEW_TAG"
-          git push origin "$NEW_TAG"
+
+          NEW_TAG="v$MAJOR_VERSION.$((MINOR_VERSION + 1))"
+          gh release create "$NEW_TAG" --title "$NEW_TAG" --generate-notes --target main


### PR DESCRIPTION
# Context
We're configuring Dependabot to automate module version updates in Platform. Since Dependabot only uses Semver, we must switch to a Semver-like tagging system.

**Needs we're trying to cover:**
1. Guarantee that the config changes are always compatible with the module if we have to make a configuration revert in the https://github.com/amenitiz/tf-config repo.
2. Automate the process of keeping the config up to date with the latest version of a module as much as possible.

**Needs we're not trying to cover:**
1. We don't need to guarantee that any version of the module has any compatibility with a previous or future version.

# Proposal
I propose bumping the minor version with every merge to the main branch. I picked the minor instead of the major because that's similar to the Kubernetes release pattern. I feel this leaves us room to use the major for other cases in the future. Feel free to propose alternatives.

Release versions will be like this:
* "v1.2"
* "v3.4"

# Validation
Here's an example of an automated release using only major and minor:

<img width="1276" alt="image" src="https://github.com/user-attachments/assets/1b460988-c47c-4cf7-b750-16940478750e" />

Here's an example of an automated release in a module with no previous matching: <img width="1505" alt="image" src="https://github.com/user-attachments/assets/1a70ee6a-c683-447c-8fd0-1ca5883c28ef" />

And here's an example of Dependabot detecting the new version: <img width="956" alt="image" src="https://github.com/user-attachments/assets/830d64b0-c810-4759-8ecf-1a2c8e90b98c" />